### PR TITLE
Added kubernetes files

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,6 @@
-FROM node:17-alpine
+FROM node:13.12.0-alpine
 
 WORKDIR /app
-
-#mapping environment path for node modules
-ENV PATH="./node_modules/.bin:$PATH"
 
 COPY package.json /app
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4291,6 +4291,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -4836,7 +4841,7 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
     },
     "cssdb": {
       "version": "4.4.0",
@@ -8033,7 +8038,7 @@
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "is-module": {
       "version": "1.0.0",
@@ -10210,11 +10215,11 @@
       }
     },
     "material-ui-chip-input": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/material-ui-chip-input/-/material-ui-chip-input-2.0.0-beta.2.tgz",
-      "integrity": "sha512-E+Jxv9FdAvYUsZIPohoqxqdW7LwFYOCunInJGh2WSDJ2IlCUdpCOEVazqgLQH6thaFarKDu44uGYpD1v3RdqDg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/material-ui-chip-input/-/material-ui-chip-input-1.1.0.tgz",
+      "integrity": "sha512-95JsxYtzBFUyvzLC0Ae8qo1h8heu9wcSgnGjF/Sy9QQ9pL/ufLVUyjS8uFULW4kEyeNZbZurux3KZKC3FLnoqg==",
       "requires": {
-        "clsx": "^1.0.4",
+        "classnames": "^2.2.5",
         "prop-types": "^15.6.1"
       }
     },
@@ -10595,7 +10600,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
@@ -14147,7 +14152,7 @@
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14363,7 +14368,7 @@
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^12.8.3",
     "axios": "^0.21.1",
     "jwt-decode": "^3.1.2",
-    "material-ui-chip-input": "^2.0.0-beta.2",
+    "material-ui-chip-input": "^1.1.0",
     "moment": "^2.29.1",
     "mongoose": "^5.13.5",
     "react": "^17.0.2",

--- a/infra/frontend-nginx.conf
+++ b/infra/frontend-nginx.conf
@@ -1,0 +1,14 @@
+# The identifier Backend is internal to nginx, and used to name this specific upstream
+upstream Backend {
+    # hello is the internal DNS name used by the backend Service inside Kubernetes
+    server knote;
+}
+
+server {
+    listen 5000;
+
+    location / {
+        # The following statement will proxy traffic to the upstream named Backend
+        proxy_pass http://Backend;
+    }
+}

--- a/infra/frontend.yaml
+++ b/infra/frontend.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: hello
+    tier: frontend
+  ports:
+  - protocol: "TCP"
+    port: 3000
+    targetPort: 3000
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: hello
+      tier: frontend
+      track: stable
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hello
+        tier: frontend
+        track: stable
+    spec:
+      containers:
+        - name: nginx
+          image: buddy22/play-cards
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/sbin/nginx","-s","quit"]

--- a/infra/plycard.yaml
+++ b/infra/plycard.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: knote
+spec:
+  selector:
+    app: knote
+  ports:
+    - port: 5000
+      targetPort: 5000
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: knote
+  template:
+    metadata:
+      labels:
+        app: knote
+    spec:
+      containers:
+        - name: knote
+          image: buddy22/plycard_server
+          ports:
+            - containerPort: 5000
+              hostPort: 5000
+          imagePullPolicy: Always


### PR DESCRIPTION
 Now you can run plycard on a Kubernetes cluster. 
- Added a `frontend.yaml` file that has both the services and the deployment configuration. The frontend routes the traffic to the backend with the help of nginx. I have used LoadBalancer to expose the port to the cluster IP. The image for the frontend is pulled from the docker hub with the name `buddy22/play-cards`. 
- Added a `plycard.yaml` file to run the backend service. It also uses LoadBalancer to expose the ports to the pods. The backend service image is pulled from the docker hub with the name `buddy22/plycard-service`. 
- Docker Compose is running as expected. 